### PR TITLE
Home page should be without auth

### DIFF
--- a/artic/src/components/Header/Header.jsx
+++ b/artic/src/components/Header/Header.jsx
@@ -14,7 +14,7 @@ const Header = () => {
     {
       name: "Home",
       path: "/",
-      active: authStatus,
+      active: !authStatus,
     },
     {
       name: "Login",

--- a/artic/src/main.jsx
+++ b/artic/src/main.jsx
@@ -13,7 +13,7 @@ const router = createBrowserRouter([{
   element: <App />,
   children: [{
     path: '/',
-    element: (<AuthLayout authStatus={true}>
+    element: (<AuthLayout authStatus={false}>
       <Home />
       </AuthLayout>)
   },


### PR DESCRIPTION
Home page should be shown at least even if user is not login 

I removed the authentication from the Home page and enabled the Home tab, which is shown in the listing on the header. 

![Screenshot 2025-03-02 002902](https://github.com/user-attachments/assets/5a7ebc1b-6de1-4a58-b314-fcaf9a4783cc)
