### PR TITLE
Fixed the screen size, so footer came at bottom all the time

### DIFF
--- a/artic/src/App.jsx
+++ b/artic/src/App.jsx
@@ -31,9 +31,9 @@ function App() {
   return (
     <>
       <div className="min-h-screen flex flex-wrap content-between ">
-        <div className="w-full block">
+        <div className="min-h-svh w-full block">
           <Header />
-          <main className="w-full my-3">
+          <main className="min-h-[70vh] w-full my-3">
             <Outlet />
           </main>
           <Footer />


### PR DESCRIPTION
The footer should come at the bottom.
Made the size of the main body (i.e, where all the content will display) to be 70% of the screen size

![image](https://github.com/user-attachments/assets/57240f0f-508f-49cd-b265-ad95b55bb699)
